### PR TITLE
Fixed a critical typo in fft.rs

### DIFF
--- a/src/common/fft.rs
+++ b/src/common/fft.rs
@@ -7,7 +7,7 @@ pub fn real_fft(buffer: &mut [f32]) -> &mut [microfft::Complex32] {
     match fft_size {
         8 => microfft::real::rfft_8(buffer.try_into().unwrap()),
         16 => microfft::real::rfft_16(buffer.try_into().unwrap()),
-        32 => microfft::real::rfft_16(buffer.try_into().unwrap()),
+        32 => microfft::real::rfft_32(buffer.try_into().unwrap()),
         64 => microfft::real::rfft_64(buffer.try_into().unwrap()),
         128 => microfft::real::rfft_128(buffer.try_into().unwrap()),
         256 => microfft::real::rfft_256(buffer.try_into().unwrap()),


### PR DESCRIPTION
For a buffer length of 32 the microfft::real::rfft_16 function was used which caused my project to crash on the .unwrap()